### PR TITLE
おすすめプロフィールの修正

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,10 @@
 {
+  "cron": [
+    {
+      "command": "bin/rails suggested_follow:create",
+      "schedule": "0 10 * * *"
+    }
+  ],
   "scripts": {
     "dokku": {
       "postdeploy": "bin/rails db:migrate"

--- a/app/use_cases/create_suggested_follows_use_case.rb
+++ b/app/use_cases/create_suggested_follows_use_case.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# frozen_string_literal: true
+
+class CreateSuggestedFollowsUseCase < ApplicationUseCase
+  sig { params(source_profile: Profile).void }
+  def call(source_profile:)
+    source_profile.create_suggested_follows!
+
+    nil
+  end
+end

--- a/lib/tasks/suggested_follow.rake
+++ b/lib/tasks/suggested_follow.rake
@@ -2,11 +2,11 @@
 # frozen_string_literal: true
 
 namespace :suggested_follow do
-  desc "おすすめプロフィール (自分がフォローしている人がフォローしている人) を作成する"
+  desc "おすすめプロフィールを作成する"
   task create: :environment do
     # Note: limitに指定している数値に深い意味はない
     Profile.kept.sort_by_latest_post.limit(1_000).each do |source_profile|
-      source_profile.create_suggested_follows!
+      CreateSuggestedFollowsUseCase.new.call(source_profile:)
     end
   end
 end

--- a/spec/use_cases/create_suggested_follows_use_case_spec.rb
+++ b/spec/use_cases/create_suggested_follows_use_case_spec.rb
@@ -1,0 +1,34 @@
+# typed: false
+# frozen_string_literal: true
+
+RSpec.describe CreateSuggestedFollowsUseCase do
+  context "おすすめするプロフィールが存在するとき" do
+    def setup_data
+      source_profile = FactoryBot.create(:profile)
+      profile_1 = FactoryBot.create(:profile)
+      profile_2 = FactoryBot.create(:profile)
+      profile_3 = FactoryBot.create(:profile)
+
+      FollowProfileUseCase.new.call(profile: source_profile, target_profile: profile_1)
+      FollowProfileUseCase.new.call(profile: profile_1, target_profile: profile_2)
+      FollowProfileUseCase.new.call(profile: profile_2, target_profile: profile_3)
+
+      {source_profile:, profile_1:, profile_2:, profile_3:}
+    end
+
+    it "おすすめプロフィールを作成すること" do
+      setup_data => {source_profile:, profile_1:, profile_2:, profile_3:}
+
+      expect(source_profile.followees).to contain_exactly(profile_1)
+      expect(profile_1.followees).to contain_exactly(profile_2)
+      expect(profile_2.followees).to contain_exactly(profile_3)
+      expect(source_profile.suggested_follows).to be_empty
+
+      CreateSuggestedFollowsUseCase.new.call(source_profile:)
+
+      # 自分がフォローしている人 (profile_1) がフォローしている人 (profile_2) と
+      # その人がフォローしている人 (profile_3) をおすすめするレコードが作成されているはず
+      expect(source_profile.suggested_followees).to contain_exactly(profile_2, profile_3)
+    end
+  end
+end


### PR DESCRIPTION
ref: https://github.com/mewstcom/mewst/issues/750

- おすすめのプロフィールの対象を拡大
  - 今まで: 自分がフォローしている人がフォローしている人
  - このPRから: 自分がフォローしている人がフォローしている人と、その人がフォローしている人
  - 理由: 今までの対象範囲だと相手が誰をフォローしているか正確にわかってしまうため
    - 対象を拡大したので誰をフォローしているかぼやけるはず
- おすすめのプロフィールを作成するタスクを定期実行する