### PR TITLE
メール確認ユースケースを実装

### DIFF
--- a/go/internal/usecase/confirm_email.go
+++ b/go/internal/usecase/confirm_email.go
@@ -1,0 +1,72 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/mewstcom/mewst/internal/model"
+	"github.com/mewstcom/mewst/internal/repository"
+)
+
+// ErrCodeMismatch は確認コードが一致しない場合のエラー
+var ErrCodeMismatch = errors.New("確認コードが一致しません")
+
+// ConfirmEmailUsecase はメール確認のユースケース
+type ConfirmEmailUsecase struct {
+	emailConfirmRepo *repository.EmailConfirmationRepository
+}
+
+// NewConfirmEmailUsecase はConfirmEmailUsecaseを生成する
+func NewConfirmEmailUsecase(
+	emailConfirmRepo *repository.EmailConfirmationRepository,
+) *ConfirmEmailUsecase {
+	return &ConfirmEmailUsecase{
+		emailConfirmRepo: emailConfirmRepo,
+	}
+}
+
+// ConfirmEmailInput はメール確認の入力パラメータ
+type ConfirmEmailInput struct {
+	EmailConfirmationID uuid.UUID
+	Code                string
+}
+
+// ConfirmEmailResult はメール確認の結果
+type ConfirmEmailResult struct {
+	EmailConfirmation *model.EmailConfirmation
+}
+
+// Execute は確認コードを検証し、成功した場合はレコードを更新する
+func (uc *ConfirmEmailUsecase) Execute(ctx context.Context, input ConfirmEmailInput) (*ConfirmEmailResult, error) {
+	// 有効な確認レコードを取得（有効期限内かつ未確認）
+	ec, err := uc.emailConfirmRepo.GetActiveByID(ctx, input.EmailConfirmationID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, repository.ErrNotFound
+		}
+		return nil, fmt.Errorf("メール確認レコードの取得に失敗: %w", err)
+	}
+
+	// 確認コードを検証
+	if ec.Code != input.Code {
+		return nil, ErrCodeMismatch
+	}
+
+	// 確認を成功としてマーク
+	if err := uc.emailConfirmRepo.MarkAsSucceeded(ctx, input.EmailConfirmationID); err != nil {
+		return nil, fmt.Errorf("メール確認の成功マークに失敗: %w", err)
+	}
+
+	// 更新後のレコードを取得
+	updatedEC, err := uc.emailConfirmRepo.GetByID(ctx, input.EmailConfirmationID)
+	if err != nil {
+		return nil, fmt.Errorf("更新後のメール確認レコードの取得に失敗: %w", err)
+	}
+
+	return &ConfirmEmailResult{
+		EmailConfirmation: updatedEC,
+	}, nil
+}

--- a/go/internal/usecase/confirm_email_test.go
+++ b/go/internal/usecase/confirm_email_test.go
@@ -1,0 +1,201 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mewstcom/mewst/internal/repository"
+	"github.com/mewstcom/mewst/internal/testutil"
+	"github.com/mewstcom/mewst/internal/usecase"
+)
+
+func TestConfirmEmailUsecase_Execute_Success(t *testing.T) {
+	t.Parallel()
+
+	_, tx := testutil.SetupTestDB(t)
+	ctx := context.Background()
+
+	// テスト用メール確認レコードを作成
+	emailConfirmationID := testutil.NewEmailConfirmationBuilder(t, tx).
+		WithEmail("test@example.com").
+		WithEvent("password_reset").
+		WithCode("123456").
+		Build()
+
+	// ユースケースを実行
+	emailConfirmRepo := repository.NewEmailConfirmationRepository(tx)
+	uc := usecase.NewConfirmEmailUsecase(emailConfirmRepo)
+	result, err := uc.Execute(ctx, usecase.ConfirmEmailInput{
+		EmailConfirmationID: emailConfirmationID,
+		Code:                "123456",
+	})
+
+	// アサーション
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Execute() result should not be nil")
+	}
+
+	if result.EmailConfirmation == nil {
+		t.Fatal("EmailConfirmation should not be nil")
+	}
+
+	// succeeded_at が設定されていることを確認
+	if result.EmailConfirmation.SucceededAt == nil {
+		t.Error("SucceededAt should not be nil after confirmation")
+	}
+
+	// 他のフィールドが正しいことを確認
+	if result.EmailConfirmation.Email != "test@example.com" {
+		t.Errorf("Email = %v, want %v", result.EmailConfirmation.Email, "test@example.com")
+	}
+
+	if result.EmailConfirmation.Code != "123456" {
+		t.Errorf("Code = %v, want %v", result.EmailConfirmation.Code, "123456")
+	}
+}
+
+func TestConfirmEmailUsecase_Execute_NotFound(t *testing.T) {
+	t.Parallel()
+
+	_, tx := testutil.SetupTestDB(t)
+	ctx := context.Background()
+
+	// 存在しないIDで実行
+	emailConfirmRepo := repository.NewEmailConfirmationRepository(tx)
+	uc := usecase.NewConfirmEmailUsecase(emailConfirmRepo)
+	_, err := uc.Execute(ctx, usecase.ConfirmEmailInput{
+		EmailConfirmationID: uuid.New(),
+		Code:                "123456",
+	})
+
+	// ErrNotFoundが返されることを確認
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Errorf("Execute() error = %v, want %v", err, repository.ErrNotFound)
+	}
+}
+
+func TestConfirmEmailUsecase_Execute_CodeMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, tx := testutil.SetupTestDB(t)
+	ctx := context.Background()
+
+	// テスト用メール確認レコードを作成
+	emailConfirmationID := testutil.NewEmailConfirmationBuilder(t, tx).
+		WithEmail("test@example.com").
+		WithEvent("password_reset").
+		WithCode("123456").
+		Build()
+
+	// 間違ったコードで実行
+	emailConfirmRepo := repository.NewEmailConfirmationRepository(tx)
+	uc := usecase.NewConfirmEmailUsecase(emailConfirmRepo)
+	_, err := uc.Execute(ctx, usecase.ConfirmEmailInput{
+		EmailConfirmationID: emailConfirmationID,
+		Code:                "999999",
+	})
+
+	// ErrCodeMismatchが返されることを確認
+	if !errors.Is(err, usecase.ErrCodeMismatch) {
+		t.Errorf("Execute() error = %v, want %v", err, usecase.ErrCodeMismatch)
+	}
+}
+
+func TestConfirmEmailUsecase_Execute_Expired(t *testing.T) {
+	t.Parallel()
+
+	_, tx := testutil.SetupTestDB(t)
+	ctx := context.Background()
+
+	// 有効期限切れのメール確認レコードを作成（16分前）
+	expiredTime := time.Now().Add(-16 * time.Minute)
+	emailConfirmationID := testutil.NewEmailConfirmationBuilder(t, tx).
+		WithEmail("test@example.com").
+		WithEvent("password_reset").
+		WithCode("123456").
+		WithCreatedAt(expiredTime).
+		Build()
+
+	// 実行
+	emailConfirmRepo := repository.NewEmailConfirmationRepository(tx)
+	uc := usecase.NewConfirmEmailUsecase(emailConfirmRepo)
+	_, err := uc.Execute(ctx, usecase.ConfirmEmailInput{
+		EmailConfirmationID: emailConfirmationID,
+		Code:                "123456",
+	})
+
+	// ErrNotFoundが返されることを確認（期限切れはGetActiveByIDでフィルタされる）
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Errorf("Execute() error = %v, want %v", err, repository.ErrNotFound)
+	}
+}
+
+func TestConfirmEmailUsecase_Execute_AlreadySucceeded(t *testing.T) {
+	t.Parallel()
+
+	_, tx := testutil.SetupTestDB(t)
+	ctx := context.Background()
+
+	// 既に確認済みのメール確認レコードを作成
+	succeededAt := time.Now().Add(-1 * time.Hour)
+	emailConfirmationID := testutil.NewEmailConfirmationBuilder(t, tx).
+		WithEmail("test@example.com").
+		WithEvent("password_reset").
+		WithCode("123456").
+		WithSucceededAt(succeededAt).
+		Build()
+
+	// 実行
+	emailConfirmRepo := repository.NewEmailConfirmationRepository(tx)
+	uc := usecase.NewConfirmEmailUsecase(emailConfirmRepo)
+	_, err := uc.Execute(ctx, usecase.ConfirmEmailInput{
+		EmailConfirmationID: emailConfirmationID,
+		Code:                "123456",
+	})
+
+	// ErrNotFoundが返されることを確認（確認済みはGetActiveByIDでフィルタされる）
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Errorf("Execute() error = %v, want %v", err, repository.ErrNotFound)
+	}
+}
+
+func TestConfirmEmailUsecase_Execute_WithinExpiry(t *testing.T) {
+	t.Parallel()
+
+	_, tx := testutil.SetupTestDB(t)
+	ctx := context.Background()
+
+	// 有効期限内のメール確認レコードを作成（14分前 = まだ有効）
+	validTime := time.Now().Add(-14 * time.Minute)
+	emailConfirmationID := testutil.NewEmailConfirmationBuilder(t, tx).
+		WithEmail("test@example.com").
+		WithEvent("password_reset").
+		WithCode("123456").
+		WithCreatedAt(validTime).
+		Build()
+
+	// 実行
+	emailConfirmRepo := repository.NewEmailConfirmationRepository(tx)
+	uc := usecase.NewConfirmEmailUsecase(emailConfirmRepo)
+	result, err := uc.Execute(ctx, usecase.ConfirmEmailInput{
+		EmailConfirmationID: emailConfirmationID,
+		Code:                "123456",
+	})
+
+	// 成功することを確認
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if result.EmailConfirmation.SucceededAt == nil {
+		t.Error("SucceededAt should not be nil after confirmation")
+	}
+}


### PR DESCRIPTION
- internal/usecase/confirm_email.go を追加
- 確認コード検証と成功マーク処理を実装
- ErrCodeMismatch エラー変数を追加
- 正常系・異常系のテストを追加