### PR TITLE
パスワードリセット機能のルーティングを統合

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -14,7 +14,11 @@ import (
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/mewstcom/mewst/internal/config"
 	"github.com/mewstcom/mewst/internal/database"
+	"github.com/mewstcom/mewst/internal/email"
+	"github.com/mewstcom/mewst/internal/handler/email_confirmation"
 	"github.com/mewstcom/mewst/internal/handler/manifest"
+	"github.com/mewstcom/mewst/internal/handler/password"
+	"github.com/mewstcom/mewst/internal/handler/password_reset"
 	"github.com/mewstcom/mewst/internal/handler/sign_in"
 	"github.com/mewstcom/mewst/internal/handler/sign_out"
 	"github.com/mewstcom/mewst/internal/middleware"
@@ -51,12 +55,24 @@ func main() {
 	userRepo := repository.NewUserRepository(db)
 	sessionRepo := repository.NewSessionRepository(db)
 	actorRepo := repository.NewActorRepository(db)
+	emailConfirmationRepo := repository.NewEmailConfirmationRepository(db)
 
 	// セッションマネージャーの初期化
 	sessionMgr := session.NewManager(sessionRepo, actorRepo, userRepo, cfg)
 
+	// メール送信クライアントの初期化
+	var emailSender email.Sender
+	if cfg.ResendAPIKey != "" && cfg.EmailFrom != "" {
+		emailSender = email.NewResendSender(cfg.ResendAPIKey, cfg.EmailFrom)
+	} else {
+		emailSender = email.NewNoopSender()
+		slog.Warn("Resend APIキーまたは送信元メールアドレスが設定されていないため、メール送信は無効です")
+	}
+
 	// ユースケースの初期化
 	createSessionUC := usecase.NewCreateSessionUsecase(sessionRepo)
+	createEmailConfirmationUC := usecase.NewCreateEmailConfirmationUsecase(emailConfirmationRepo, emailSender)
+	updatePasswordUC := usecase.NewUpdatePasswordUsecase(userRepo)
 
 	// Turnstileクライアントの初期化
 	turnstileClient := turnstile.NewClient(cfg.TurnstileSecretKey)
@@ -65,6 +81,9 @@ func main() {
 	manifestHandler := manifest.NewHandler(cfg)
 	signInHandler := sign_in.NewHandler(cfg, sessionMgr, userRepo, actorRepo, createSessionUC, turnstileClient)
 	signOutHandler := sign_out.NewHandler(cfg, sessionMgr)
+	passwordResetHandler := password_reset.NewHandler(cfg, sessionMgr, createEmailConfirmationUC, turnstileClient)
+	emailConfirmationHandler := email_confirmation.NewHandler(cfg, sessionMgr, emailConfirmationRepo)
+	passwordHandler := password.NewHandler(cfg, sessionMgr, emailConfirmationRepo, updatePasswordUC)
 
 	// ミドルウェアの初期化
 	authMiddleware := middleware.NewAuth(sessionMgr)
@@ -126,6 +145,25 @@ func main() {
 		r.Use(authMiddleware.RequireAuth)
 		r.Delete("/sign_out", signOutHandler.Delete)
 		r.Post("/sign_out", signOutHandler.Delete)
+	})
+
+	// パスワードリセット機能（未認証ユーザーのみ）
+	r.Group(func(r chi.Router) {
+		r.Use(csrfMiddleware.Middleware)
+		r.Use(authMiddleware.RequireNoAuth)
+
+		// パスワードリセット開始（メールアドレス入力）
+		r.Get("/password_reset", passwordResetHandler.New)
+		r.Post("/password_reset", passwordResetHandler.Create)
+
+		// メール確認（確認コード入力）
+		r.Get("/email_confirmation", emailConfirmationHandler.New)
+		r.Post("/email_confirmation", emailConfirmationHandler.Create)
+
+		// パスワード更新（新しいパスワード設定）
+		r.Get("/password/edit", passwordHandler.Edit)
+		r.Patch("/password", passwordHandler.Update)
+		r.Post("/password", passwordHandler.Update) // HTMLフォームからのPOST対応（_method=PATCH）
 	})
 
 	// サーバー起動

--- a/go/internal/middleware/reverse_proxy.go
+++ b/go/internal/middleware/reverse_proxy.go
@@ -23,11 +23,14 @@ type ReverseProxyMiddleware struct {
 // Go版で処理するパス（ホワイトリスト）
 // これらのパスはRails版にプロキシせず、Go版のハンドラーで処理する
 var goHandledPaths = []string{
-	"/static",        // 静的ファイル（CSS、JS、画像など）
-	"/health",        // ヘルスチェックエンドポイント
-	"/manifest.json", // Web App Manifest
-	"/sign_in",       // ログインページ・処理
-	"/sign_out",      // ログアウト処理
+	"/static",             // 静的ファイル（CSS、JS、画像など）
+	"/health",             // ヘルスチェックエンドポイント
+	"/manifest.json",      // Web App Manifest
+	"/sign_in",            // ログインページ・処理
+	"/sign_out",           // ログアウト処理
+	"/password_reset",     // パスワードリセット開始
+	"/email_confirmation", // メール確認
+	"/password",           // パスワード更新
 }
 
 // NewReverseProxyMiddleware は新しいReverseProxyMiddlewareを作成


### PR DESCRIPTION
- cmd/server/main.goにパスワードリセット関連のルーティングを追加
  - GET/POST /password_reset（パスワードリセット開始）
  - GET/POST /email_confirmation（メール確認）
  - GET /password/edit, PATCH/POST /password（パスワード更新）
- リバースプロキシのホワイトリストに新しいパスを追加
- CSRFミドルウェアと未認証ガードを適用